### PR TITLE
Revert "更新文档的分支 (#5)"

### DIFF
--- a/src/github/new-branch.js
+++ b/src/github/new-branch.js
@@ -29,7 +29,7 @@ else {
 
 
 function updatePackages (packageContent, packageJson) {
-    const { builtin, hosts, templates, externDefs, apiDocs } = packageJson;
+    const { builtin, hosts, templates, externDefs } = packageJson;
 
     // use replace to ensure line ending will not changed or it will be formated by JSON
     function ensureReplace (oldText, newText) {
@@ -59,18 +59,9 @@ function updatePackages (packageContent, packageJson) {
         });
     }
 
-    function bumpDocRepo (doc) {
-        let [repo, branch] = doc.split('#');
-        let docNewBranch = /v[0-9].[0-9]+/.exec(newBranch)[0];
-        if (branch !== docNewBranch) {
-            ensureReplace(`"${doc}"`, `"${repo}#${docNewBranch}"`);
-        }
-    }
- 
     bumpRepos(builtin);
     bumpRepos(hosts);
     bumpRepos(templates);
-    bumpDocRepo(apiDocs)
 
     for (let key in templates) {
         let url = templates[key];


### PR DESCRIPTION
This reverts commit 21addc6e03f8ec52fceeb97d7f743e1ac6b089d3.
api-doc就默认使用master分支好了，不用每个版本更新一次